### PR TITLE
ssl_chipers

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -20,6 +20,7 @@ http {
 	default_type application/octet-stream;
 
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+	ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
 	ssl_prefer_server_ciphers on;
 
 	log_format ext_combined


### PR DESCRIPTION
added ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH'; to nginx.conf.j2 to disable unsecure chipers