### PR TITLE
Better and more advance certificate handling and access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,34 +4,51 @@ Installs and configure nginx as reverse proxy. Redirects all http requests to ht
 
 If necessary, certificates are automatically obtained or renewed, anytime ansible-playbook is executed.
 Support for Unix-PAM authentication, by setting `auth` to true at target server.
+Ability to restrict target domains by ip ranges and addresses.
+Options to copy obtained certificates to target servers, when requested by them.
 
 ## Requirements
 
-A Debian based distribution with certbot available in current apt sources.
+A Debian based distribution with certbot available in current apt sources. Correct configured DNS server.
 
 ## Role Variables
-```yml
-letsencrypt_email: <your e-mail address> # Email address which should be used to request Letsencrypt certificates
-default_url: <your fallback address> # Default or fallback address (clients are redirected to this address in case target server isn't reachable)
-staging: [true|false*] # Use Letsencrypt staging server
-url_suffix: # List of suffixes automatically added to all domains
-  - ""
-url_prefix: # List of prefixes automatically added to all domains
-  - ""
-  - "www."
-proxy_targets: # List of target servers and domains served by them
-  - target: <ip> # Replace <ip> with an actually real target server
-    auth: [true|false*] # Set auth either to true or false (enables Unix PAM authentication)
-    domains: # List of domains served by this target server
-      - example.com
-      - fuu.de
-      - testserver.bla.org
 
-# * default value
-```
-**WARNING:** `letsencrypt_email` **is required, if not specified no certificates are requested and deployed**
+### Primary
+| Option             | Type            | Default                                   | Description                                                         | Required |
+|--------------------|-----------------|-------------------------------------------|---------------------------------------------------------------------|:--------:|
+| proxy_domains      | list of dicts   |                                           | List of all target servers                                          |     Y    |
+| default_url        | string          | https://github.com/stuvusIT/reverse_proxy | Url to redirect to if no target with requested domain is restricted |     N    |
+| letsencrypt_email  | string          | false                                     | E-Mail address to use to request certificates                       |     Y    |
+| default_cert_mode  | string          | 0400                                      | Default file access mode on certificates at target servers          |     N    |
+| default_cert_group | string          | root                                      | Default owner group for certificates at target servers              |     N    |
+| default_cert_owner | string          | root                                      | Default owner user for certificates at target servers               |     N    |
+| default_crypto     | boolean         | true                                      | Use https as default to forward traffic                             |     N    |
+| domain_suffixes    | list of strings | `['']`                                    | Domain suffixes to append to every not full qualified domain name   |     N    |
+| domain_prefixes    | list of strings | `['']`                                    | Domain prefixes to append to every not full qualified domain name   |     N    |
 
-Default values are specified [here](defaults/main.yml) (except auth, which is specified by template file).
+
+### proxy_domains
+| Option             | Type          | Default | Description                                                                  | Required |
+|--------------------|---------------|---------|------------------------------------------------------------------------------|:--------:|
+| target_description | string        |         | A short description of the target server                                     |     Y    |
+| target_host        | string        |         | Ansible host name (will be used to copy request certificates)                |     Y    |
+| target_ip          | string        |         | IP address off target server (will be used as target address to redirect to) |     Y    |
+| served_domains     | list of dicts |         | List of all domain lists served by this target server                        |     Y    |
+
+### served_domains
+| Option         | Type          | Default            | Description                                                  | Required |
+|----------------|---------------|--------------------|--------------------------------------------------------------|:--------:|
+| port           | integer       |                    | Target port to redirect to                                   |     N    |
+| crypto         | boolean       | {{default_crypto}} | Use https to forward traffic                                 |     N    |
+| auth           | boolean       | false              | restrict access to system users                              |     N    |
+| access_control | list of dicts |                    | A list of dicts to restrict access to given set of ip ranges |     N    |
+
+### access_control
+| Option | Type   | Default | Description                   | Required |
+|--------|--------|---------|-------------------------------|:--------:|
+| allow  | string |         | IP address or subnet to allow |     N    |
+| deny   | string |         | IP address or subnet to deny  |     N    |
+These dicts are evaluated in given order, so a complete subnet can be allowed with the exception of a given ip, see: [nginx doku](http://nginx.org/en/docs/http/ngx_http_access_module.html#allow) for future information.
 
 ## Dependencies
 
@@ -40,49 +57,41 @@ Default values are specified [here](defaults/main.yml) (except auth, which is sp
 
 ### Vars:
 ```yml
-letsencrypt_email: test@example.com
-default_url: www.example.com
-url_suffix:
-  - example.com
-  - example.my-domain.com
-url_prefix:
-  - ""
-  - "www"
-proxy_targets:
-  - target: 172.30.0.2
+letsencrypt_email: hostmaster@example.com
+default_url: https://stuvus.uni-stuttgart.de
+domain_suffixes:
+	- "example.com"
+proxy_domains:
+- target_description: music player
+  target_host: mpd01
+  target_ip: 172.27.10.66
+  served_domains:
+  - access_control:
+    - allow: 172.27.0.0/16
+    - deny: all
+    port: 6680
+    https: false
     domains:
-      - pictures
-      - images
-  - target: 172.30.0.2
-    auth: true
+    - mpd
+- target_description: DokoWiki
+  target_host: validator
+  target_ip: 172.27.10.101
+  served_domains:
+  - auth: true
     domains:
-      - private.pictures
-  - target: 172.30.0.3
-    auth: false
-    domains:
-      - static
+    - wiki
+    - www.wiki
+	- wiki.wiki.de.
 ```
 ### Result:
 This example playbook redirects as follows:
 
-| domain                                     | target server | authentication required |
-|--------------------------------------------|---------------|-------------------------|
-| pictures.example.com                       | 172.30.0.2    | no                      |
-| pictures.example.my-domain.com             | 172.30.0.2    | no                      |
-| www.pictures.example.com                   | 172.30.0.2    | no                      |
-| www.pictures.example.my-domain.com         | 172.30.0.2    | no                      |
-| images.example.com                         | 172.30.0.2    | no                      |
-| www.images.example.my-domain.com           | 172.30.0.2    | no                      |
-| www.images.example.com                     | 172.30.0.2    | no                      |
-| images.example.my-domain.com               | 172.30.0.2    | no                      |
-| private.pictures.example.com               | 172.30.0.2    | yes                     |
-| private.pictures.example.my-domain.com     | 172.30.0.2    | yes                     |
-| www.private.pictures.example.com           | 172.30.0.2    | yes                     |
-| www.private.pictures.example.my-domain.com | 172.30.0.2    | yes                     |
-| static.example.com                         | 172.30.0.3    | no                      |
-| static.example.my-domain.com               | 172.30.0.3    | no                      |
-| www.static.example.com                     | 172.30.0.3    | no                      |
-| www.static.example.my-domain.com           | 172.30.0.3    | no                      |
+| domain               | redirected to            | restrictions                         |
+|----------------------|--------------------------|--------------------------------------|
+| mpd.example.com      | http://172.27.10.66:6680 | allow: 172.27.0.0/16, deny all other |
+| wiki.example.com     | https://172.27.10.101    | only system users                    |
+| www.wiki.example.com | https://172.27.10.101    | only system users                    |
+| wiki.wiki.de         | https://172.27.10.101    | only system users                    |
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ letsencrypt_email: false # Do not execute letsencrypt
 default_cert_mode: '0400'
 default_cert_group: root
 default_cert_owner: root
+default_crypto: true
 domain_suffixes:
   - ""
 domain_prefixes:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,8 +3,11 @@ hsts_max_age: 300 #for staging and safty reasons(it's a one-way ticket) 5minutes
 staging: false
 default_url: https://github.com/stuvusIT/reverse_proxy
 letsencrypt_email: false # Do not execute letsencrypt
-url_suffix:
+default_cert_mode: '0400'
+default_cert_group: root
+default_cert_owner: root
+domain_suffixes:
   - ""
-url_prefix:
+domain_prefixes:
   - ""
-proxy_targets: []
+proxy_domains: []

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -1,0 +1,18 @@
+---
+- name: Obtain/Renew certificates
+  command: '{% from "roles/reverse_proxy/templates/macros.j2" import build_domain_list_for_domains with context %}{#Fuck Ansible, you need to speciefy a absolute path #}
+    certbot certonly {% if staging %}--staging {% endif %}
+    --webroot --keep-until-expiring --expand --non-interactive --agree-tos
+    -m {{ letsencrypt_email }} -t -w /var/www/html
+    {{ build_domain_list_for_domains( item, " -d " ) }}'
+  with_items: "{{ target.served_domains }}"
+  register: certUpdate
+  changed_when: certUpdate.stdout_lines[2]|default('') != 'Certificate not yet due for renewal; no action taken.'
+  notify: Reload nginx
+
+
+- name: Copy all needed certificates to target servers
+  include: copy_certs.yml
+  with_items: "{{ target.served_domains }}"
+  loop_control:
+    loop_var: domains

--- a/tasks/copy_cert.yml
+++ b/tasks/copy_cert.yml
@@ -1,0 +1,20 @@
+---
+- name: Fetch certificate from reverse proxy ({{ cert_type }})
+  slurp:
+    src: '{%- from "roles/reverse_proxy/templates/macros.j2" import build_domain_list_for_domains with context -%}
+    /etc/letsencrypt/live/{{- build_domain_list_for_domains( domains, " " ).split(" ")[1] -}}/{{- cert_type -}}.pem'
+  register: current_certificate
+  when: "domains.{{ cert_type }}_path is defined"
+
+- debug:
+    msg: "{{ current_certificate }}"
+
+- name: Push certificate to target server ({{ cert_type }})
+  copy:
+    content: "{{ current_certificate.content | b64decode }}"
+    dest: "{{ domains[cert_type + '_path'] }}"
+    mode: "{{ domains[cert_type + '_mode'] | default(default_cert_mode) }}"
+    group: "{{ domains[cert_type + '_group'] | default(default_cert_group) }}"
+    owner: "{{ domains[cert_type + '_owner'] | default(default_cert_owner) }}"
+  delegate_to: "{{ target.target_host }}"
+  when: "domains.{{ cert_type }}_path is defined"

--- a/tasks/copy_cert.yml
+++ b/tasks/copy_cert.yml
@@ -6,9 +6,6 @@
   register: current_certificate
   when: "domains.{{ cert_type }}_path is defined"
 
-- debug:
-    msg: "{{ current_certificate }}"
-
 - name: Push certificate to target server ({{ cert_type }})
   copy:
     content: "{{ current_certificate.content | b64decode }}"

--- a/tasks/copy_certs.yml
+++ b/tasks/copy_certs.yml
@@ -1,5 +1,5 @@
 ---
-- name: Copy all need certificat to target server
+- name: Copy all needed certificat to target server({{ target.target_host }})
   include: copy_cert.yml
   loop_control:
     loop_var: cert_type

--- a/tasks/copy_certs.yml
+++ b/tasks/copy_certs.yml
@@ -1,0 +1,12 @@
+---
+- name: Copy all need certificat to target server
+  include: copy_cert.yml
+  loop_control:
+    loop_var: cert_type
+  with_items:
+    - cert
+    - chain
+    - fullchain
+    - privkey
+  when: "domains.{{ cert_type }}_path is defined"
+

--- a/tasks/letsencrypt.yml
+++ b/tasks/letsencrypt.yml
@@ -3,11 +3,8 @@
   apt:
     name: certbot
   when: ansible_pkg_mgr == "apt"
-
-- name: Obtain/Renew certificates
-  command: certbot certonly {% if staging %}--staging {% endif %}--webroot --keep-until-expiring --expand --non-interactive --agree-tos -m {{letsencrypt_email}} -t -w /var/www/html {% for domain in item.domains%}{% for prefix in url_prefix %}{% for suffix in url_suffix %}-d {{prefix}}{% if prefix!='' %}.{% endif %}{{domain}}{% if suffix!='' %}.{% endif %}{{suffix}} {% endfor %}{% endfor %}{% endfor %}
-  register: certUpdate
-  changed_when: certUpdate.stdout_lines[2] != 'Certificate not yet due for renewal; no action taken.'
-  with_items: "{{ proxy_targets }}"
-  notify: Reload nginx
-  when: letsencrypt_email != false
+  
+- include: certificates.yml
+  with_items: "{{ proxy_domains }}"
+  loop_control:
+    loop_var: target

--- a/templates/macros.j2
+++ b/templates/macros.j2
@@ -17,10 +17,10 @@
 		{{- separator -}}{{ domain[:-1] }}
 	{%- else -%}
 		{%- for prefix in domain_prefixes -%}{#- append all domain prefixes -#}
-		{%- for suffix in domain_suffixes -%}{#- append all domain suffixes -#}
-		{#- output domain name with appended prefix and suffix, with given separator -#}
-		{{- separator -}}{{- fix_domain( [prefix,domain,suffix] | join('.') ) -}}
-		{%- endfor -%}
+			{%- for suffix in domain_suffixes -%}{#- append all domain suffixes -#}
+				{#- output domain name with appended prefix and suffix, with given separator -#}
+				{{- separator -}}{{- fix_domain( [prefix,domain,suffix] | join('.') ) -}}
+			{%- endfor -%}
 		{%- endfor -%}
 	{%- endif -%}
 {%- endmacro -%}

--- a/templates/macros.j2
+++ b/templates/macros.j2
@@ -1,0 +1,32 @@
+{# vim: sw=4 ts=4 #}
+{%- macro fix_domain(domain) -%}{#- remove leading and following dot -#}
+	{%- if domain[0] == '.' and domain[-1] == '.' -%}
+		{{- domain[1:-1] -}}
+	{%- elif domain[0] == '.' -%}
+		{{- domain[1:] -}}
+	{%- elif domain[-1] == '.' -%}
+		{{- domain[:-1] -}}
+	{% else %}
+		{{- domain -}}
+	{%- endif -%}
+{%- endmacro -%}
+
+{%- macro build_domain_list(domain, separator) -%}
+	{%- if domain[-1] == '.' -%}{#- domain is already a full qualified domain name -#}
+		{#- output domain name with appended prefix and suffix, with given separator and without leading dot -#}
+		{{- separator -}}{{ domain[:-1] }}
+	{%- else -%}
+		{%- for prefix in domain_prefixes -%}{#- append all domain prefixes -#}
+		{%- for suffix in domain_suffixes -%}{#- append all domain suffixes -#}
+		{#- output domain name with appended prefix and suffix, with given separator -#}
+		{{- separator -}}{{- fix_domain( [prefix,domain,suffix] | join('.') ) -}}
+		{%- endfor -%}
+		{%- endfor -%}
+	{%- endif -%}
+{%- endmacro -%}
+
+{%- macro build_domain_list_for_domains(domains, separator) -%}
+	{%- for domain in domains.domains -%}
+		{{- build_domain_list( domain, separator ) -}}
+	{%- endfor -%}
+{%- endmacro -%}

--- a/templates/reverse_proxy.conf.j2
+++ b/templates/reverse_proxy.conf.j2
@@ -1,37 +1,34 @@
 # vim: sw=4 ts=4 ft=nginx
 # {{ ansible_managed }}
 
-{% for target in proxy_targets %}
+{% from "macros.j2" import build_domain_list_for_domains, build_domain_list with context %}
+
+{%- for target in proxy_domains -%}
+{% for domains in target.served_domains %}
+# {{ target.target_host }}
+#  authentication: {% if target.auth|default(False) -%} enabled {%- else -%} disabled {%- endif %}{{ '' }}
+#  description: {{ target.target_description }}
 server {
 	ssl on;
 	charset utf-8;
 	listen 443 ssl;
 
-	server_name
-{% for domain in target.domains%}
-{% for prefix in url_prefix %}
-{% for suffix in url_suffix %}
-{{prefix}}{% if prefix!='' %}.{% endif %}{{domain}}{% if suffix!='' %}.{% endif %}{{suffix}}
-{% endfor %}
-{% endfor %}
-{% endfor %};
+	server_name {{- build_domain_list_for_domains( domains, ' ' ) -}};
 
-	ssl_certificate     /etc/letsencrypt/live/{{url_prefix[0]}}{% if url_prefix[0]!='' %}.{% endif %}{{target.domains[0]}}{% if url_suffix[0]!='' %}.{% endif %}{{url_suffix[0]}}/fullchain.pem;
-	ssl_certificate_key /etc/letsencrypt/live/{{url_prefix[0]}}{% if url_prefix[0]!='' %}.{% endif %}{{target.domains[0]}}{% if url_suffix[0]!='' %}.{% endif %}{{url_suffix[0]}}/privkey.pem;
+	ssl_certificate     /etc/letsencrypt/live/{{- build_domain_list_for_domains( domains, ' ' ).split(' ')[1] -}}/fullchain.pem;
+	ssl_certificate_key /etc/letsencrypt/live/{{- build_domain_list_for_domains( domains, ' ' ).split(' ')[1] -}}/privkey.pem;
 
 	location / {
-		if ($http_user_agent !~ "Encrypt validation server" ) {
-			add_header Strict-Transport-Security "max-age={{ hsts_max_age }}; includeSubDomains; preload" always; #lets encrypt has to be excluded from hsts
-		}
-		proxy_pass        http://{{ target.target }};
+		add_header Strict-Transport-Security "max-age={{ hsts_max_age }}; includeSubDomains; preload" always;
+		proxy_pass        http://{{ target.target_ip }};
 		proxy_redirect    off;
-		proxy_set_header  Host               {{ target.target }};
+		proxy_set_header  Host               {{ target.target_ip }};
 		proxy_set_header  X-Real-IP          $remote_addr;
 		proxy_set_header  X-Forwarded-For    $proxy_add_x_forwarded_for;
 		proxy_set_header  X-Forwarded-Proto  $scheme;
 		proxy_set_header  X-Forwarded-Port   $server_port;
 
-{% if target.auth|default(False) %}
+{% if domains.auth|default(False) %}
 		auth_pam              "Admins Only";
 		auth_pam_service_name "pam_unix";
 {% endif %}
@@ -42,8 +39,9 @@ server {
 		if ($http_user_agent !~ "Encrypt validation server" ) {
 			add_header Strict-Transport-Security "max-age={{ hsts_max_age }}; includeSubDomains; preload" always; #lets encrypt has to be excluded from hsts
 		}
-		return 302 {{default_url}};
+		return 302 {{default_url|default('http://example.com')}};
 	}
 }
 
 {% endfor %}
+{%- endfor -%}

--- a/templates/reverse_proxy.conf.j2
+++ b/templates/reverse_proxy.conf.j2
@@ -20,7 +20,13 @@ server {
 
 	location / {
 		add_header Strict-Transport-Security "max-age={{ hsts_max_age }}; includeSubDomains; preload" always;
-		proxy_pass        http://{{ target.target_ip }};
+		proxy_pass        {{ '' }}
+		{%- if domains.crypto|default(default_crypto) -%}
+			https://
+		{%- else -%}
+			http://
+		{%- endif -%}{{- target.target_ip -}}
+		{%- if domains.port is defined -%}:{{- domains.port -}}{%- endif -%};
 		proxy_redirect    off;
 		proxy_set_header  Host               {{ target.target_ip }};
 		proxy_set_header  X-Real-IP          $remote_addr;
@@ -31,6 +37,12 @@ server {
 {% if domains.auth|default(False) %}
 		auth_pam              "Admins Only";
 		auth_pam_service_name "pam_unix";
+{% endif %}
+
+{% if domains.access_control is defined %}
+{% for access_control in domains.access_control %}
+		{{ access_control | first }}	{{ access_control[access_control | first] }};
+{% endfor %}
 {% endif %}
 	}
 

--- a/templates/reverse_proxy.conf.j2
+++ b/templates/reverse_proxy.conf.j2
@@ -40,9 +40,9 @@ server {
 {% endif %}
 
 {% if domains.access_control is defined %}
-{% for access_control in domains.access_control %}
+	{% for access_control in domains.access_control %}
 		{{ access_control | first }}	{{ access_control[access_control | first] }};
-{% endfor %}
+	{% endfor %}
 {% endif %}
 	}
 


### PR DESCRIPTION
* obtain for every domain subset in served_domains a own certificate
* copy requested certificates to target server, when requested by them
* ability to set the owner, group, mode, type of requested certificates and path independently
* ability to add multiple allow and deny directives per domain list
* use https as default to redirect traffic to target servers
* ability to set target port per domain list