### PR TITLE
Add option to define custom locations blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,30 +37,31 @@ A Debian based distribution with certbot available in current apt sources. Corre
 | served_domains     | list of dicts |         | List of all domain lists served by this target server                       |     Y    |
 
 ### served_domains
-| Option               | Type            | Default                                | Description                                                                        | Required |
-|----------------------|-----------------|----------------------------------------|------------------------------------------------------------------------------------|:--------:|
-| port                 | integer         |                                        | Target port to redirect to                                                         |     N    |
-| crypto               | boolean         | [`{{ default_crypto }}`](#primary)     | Use https to forward traffic                                                       |     N    |
-| auth                 | boolean         | `false`                                | restrict access to system users                                                    |     N    |
-| domains              | list of strings |                                        | A list of domains to proxy [(see below for more information)¹](#served_domains__1) |     Y    |
-| access_control       | list of dicts   |                                        | A list of dicts to restrict access to given set of ip ranges                       |     N    |
-| fullchain_path       | string          |                                        | [Destination path²](#served_domains__2) for fullchain.pem at _target_host_         |     N    |
-| cert_path            | string          |                                        | [Destination path²](#served_domains__2) for cert.pem at _target_host_              |     N    |
-| chain_path           | string          |                                        | [Destination path²](#served_domains__2) for chain.pem at _target_host_             |     N    |
-| privkey_path         | string          |                                        | [Destination path²](#served_domains__2) for privkey.pem at _target_host_           |     N    |
-| fullchain_mode       | string          | [`{{ default_cert_mode }}`](#primary)  | File access mode for fullchain.pwm at _target_host_                                |     N    |
-| cert_mode            | string          | [`{{ default_cert_mode }}`](#primary)  | File access mode for cert.pwm at _target_host_                                     |     N    |
-| chain_mode           | string          | [`{{ default_cert_mode }}`](#primary)  | File access mode for chain.pwm at _target_host_                                    |     N    |
-| privkey_mode         | string          | [`{{ default_cert_mode }}`](#primary)  | File access mode for privkey.pwm at _target_host_                                  |     N    |
-| fullchain_group      | string          | [`{{ default_cert_group }}`](#primary) | Owner group of fullchain.pwm at _target_host_                                      |     N    |
-| cert_group           | string          | [`{{ default_cert_group }}`](#primary) | Owner group of cert.pwm at _target_host_                                           |     N    |
-| chain_group          | string          | [`{{ default_cert_group }}`](#primary) | Owner group of chain.pwm at _target_host_                                          |     N    |
-| privkey_group        | string          | [`{{ default_cert_group }}`](#primary) | Owner group of privkey.pwm at _target_host_                                        |     N    |
-| fullchain_owner      | string          | [`{{ default_cert_owner }}`](#primary) | Owner of fullchain.pwm at _target_host_                                            |     N    |
-| cert_owner           | string          | [`{{ default_cert_owner }}`](#primary) | Owner of cert.pwm at _target_host_                                                 |     N    |
-| chain_owner          | string          | [`{{ default_cert_owner }}`](#primary) | Owner of chain.pwm at _target_host_                                                |     N    |
-| privkey_owner        | string          | [`{{ default_cert_owner }}`](#primary) | Owner of privkey.pwm at _target_host_                                              |     N    |
-| client_max_body_size | string          |                                        | Set the maximum upload size at server context                                      |     N    |
+| Option               | Type                    | Default                                | Description                                                                                                         | Required |
+|----------------------|-------------------------|----------------------------------------|---------------------------------------------------------------------------------------------------------------------|:--------:|
+| port                 | integer                 |                                        | Target port to redirect to                                                                                          |     N    |
+| crypto               | boolean                 | [`{{ default_crypto }}`](#primary)     | Use https to forward traffic                                                                                        |     N    |
+| auth                 | boolean                 | `false`                                | restrict access to system users                                                                                     |     N    |
+| domains              | list of strings         |                                        | A list of domains to proxy [(see below for more information)¹](#served_domains__1)                                  |     Y    |
+| access_control       | list of dicts           |                                        | A list of dicts to restrict access to given set of ip ranges                                                        |     N    |
+| fullchain_path       | string                  |                                        | [Destination path²](#served_domains__2) for fullchain.pem at _target_host_                                          |     N    |
+| cert_path            | string                  |                                        | [Destination path²](#served_domains__2) for cert.pem at _target_host_                                               |     N    |
+| chain_path           | string                  |                                        | [Destination path²](#served_domains__2) for chain.pem at _target_host_                                              |     N    |
+| privkey_path         | string                  |                                        | [Destination path²](#served_domains__2) for privkey.pem at _target_host_                                            |     N    |
+| fullchain_mode       | string                  | [`{{ default_cert_mode }}`](#primary)  | File access mode for fullchain.pwm at _target_host_                                                                 |     N    |
+| cert_mode            | string                  | [`{{ default_cert_mode }}`](#primary)  | File access mode for cert.pwm at _target_host_                                                                      |     N    |
+| chain_mode           | string                  | [`{{ default_cert_mode }}`](#primary)  | File access mode for chain.pwm at _target_host_                                                                     |     N    |
+| privkey_mode         | string                  | [`{{ default_cert_mode }}`](#primary)  | File access mode for privkey.pwm at _target_host_                                                                   |     N    |
+| fullchain_group      | string                  | [`{{ default_cert_group }}`](#primary) | Owner group of fullchain.pwm at _target_host_                                                                       |     N    |
+| cert_group           | string                  | [`{{ default_cert_group }}`](#primary) | Owner group of cert.pwm at _target_host_                                                                            |     N    |
+| chain_group          | string                  | [`{{ default_cert_group }}`](#primary) | Owner group of chain.pwm at _target_host_                                                                           |     N    |
+| privkey_group        | string                  | [`{{ default_cert_group }}`](#primary) | Owner group of privkey.pwm at _target_host_                                                                         |     N    |
+| fullchain_owner      | string                  | [`{{ default_cert_owner }}`](#primary) | Owner of fullchain.pwm at _target_host_                                                                             |     N    |
+| cert_owner           | string                  | [`{{ default_cert_owner }}`](#primary) | Owner of cert.pwm at _target_host_                                                                                  |     N    |
+| chain_owner          | string                  | [`{{ default_cert_owner }}`](#primary) | Owner of chain.pwm at _target_host_                                                                                 |     N    |
+| privkey_owner        | string                  | [`{{ default_cert_owner }}`](#primary) | Owner of privkey.pwm at _target_host_                                                                               |     N    |
+| client_max_body_size | string                  |                                        | Set the maximum upload size at server context                                                                       |     N    |
+| extra_locations      | list of key value dicts | []                                     | Add custom locations to this server block, the key should be a location string, the value defines the location body |     N    |
 
 <a id="served_domains__1">¹</a> Can be either a fully qualified domain name(with following dot ex. `www.example.com.`) or a short internal domain(will be expanded by `domain_suffixes` and `domain_prefixes` ex. `wiki` or `static.media`)
 

--- a/templates/reverse_proxy.conf.j2
+++ b/templates/reverse_proxy.conf.j2
@@ -37,19 +37,25 @@ server {
 		proxy_set_header  X-Forwarded-For    $proxy_add_x_forwarded_for;
 		proxy_set_header  X-Forwarded-Proto  $scheme;
 		proxy_set_header  X-Forwarded-Port   $server_port;
-
 {% if domains.auth|default(False) %}
+
 		auth_pam              "Admins Only";
 		auth_pam_service_name "pam_unix";
 {% endif %}
-
 {% if domains.access_control is defined %}
+
 	{% for access_control in domains.access_control %}
 		{{ access_control | first }}	{{ access_control[access_control | first] }};
 	{% endfor %}
 {% endif %}
 	}
 
+{% for location_block in domains.extra_locations|default([]) %}
+	location {{ location_block|first }} {
+		{{ location_block[location_block|first] }}
+	}
+
+{% endfor %}
 	error_page 502 @defaultHost;
 	location @defaultHost {
 		if ($http_user_agent !~ "Encrypt validation server" ) {


### PR DESCRIPTION
Users can now define custom nginx location blocks per served domain
entry. This is for ex. useful to proxy a specific location to another
uplink server or to define special nginx parameters.