### PR TITLE
Enable deferred and reuseport

### DIFF
--- a/templates/reverse_proxy.conf.j2
+++ b/templates/reverse_proxy.conf.j2
@@ -4,6 +4,7 @@
 {% from "macros.j2" import build_domain_list_for_domains, build_domain_list with context %}
 
 {%- for target in proxy_domains -%}
+{%- set outer_loop = loop -%}
 {% for domains in target.served_domains %}
 # {{ target.target_host }}
 #  authentication: {% if target.auth|default(False) -%} enabled {%- else -%} disabled {%- endif %}{{ '' }}
@@ -11,7 +12,7 @@
 server {
 	ssl on;
 	charset utf-8;
-	listen 443 {% if domains.enable_http2_proxy is not defined or not domains.enable_http2_proxy %} http2 {% endif %} ssl;
+	listen 443 {% if domains.enable_http2_proxy is not defined or not domains.enable_http2_proxy %} http2 {% endif %} {%- if outer_loop.index == 2 %} deferred reuseport {%- endif %} ssl;
 
 	server_name {{- build_domain_list_for_domains( domains, ' ' ) -}};
 


### PR DESCRIPTION
This is only done for the first `listen`, because nginx will fail
otherwise. Idk why the first element is `2` instead of `1`, but as long
as it's only set on ONE server (doesn't have to be the first), it works.

Also, that `outer_loop` stuff is required because the nested loop will
override `loop`.

`deferred` enables `TCP_DEFER_ACCEPT` (see the corresponding man pages),
this basically allows for faster connection establishments.

`reuseport` enables `SO_REUSEPORT`, this has security implications
because another process on the machine can bind to port `80` as well,
allowing it to get some connections. However, when only nginx listens on
port `80`, every worker process can listen instead of just the master
process. This way, the kernel is able to distribute connections between
the worker processes in kernel space instead of the nginx master process
in user space, which should improve performance when many connections
are opened. More info here: https://lwn.net/Articles/542629/