### PR TITLE
feat(reverse_proxy): fail if proxy_domains is undefined

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -65,4 +65,3 @@ domain_suffixes:
   - ""
 domain_prefixes:
   - ""
-proxy_domains: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - import_tasks: install.yml
 - include_tasks: certificates.yml
-  with_items: "{{ proxy_domains }}"
+  with_items: "{{ proxy_domains | mandatory }}"
   loop_control:
     loop_var: target
   tags:


### PR DESCRIPTION
If you deploy this role on a host without `reverse_proxy_mklist` an empty nginx config is the result.